### PR TITLE
fix numpy sum error

### DIFF
--- a/timflow/steady/linesink.py
+++ b/timflow/steady/linesink.py
@@ -1019,7 +1019,7 @@ class RiverString(LineSinkStringBase2):
         # include resistance by computing position of coefficients in matrix
         # and subtracting resistance terms
         iself = self.model.elementlist.index(self)
-        jcol = np.sum([e.nunknowns for e in self.model.elementlist[:iself]]).astype(int)
+        jcol = sum([e.nunknowns for e in self.model.elementlist[:iself]])
         irow = 0
         for ls in self.lslist:
             for icp in range(ls.ncp):


### PR DESCRIPTION
Fixes this numpy error (have to check for more):
Calling np.sum(generator) is deprecated.Use np.sum(np.fromiter(generator)) or the python sum builtin instead.