### PR TITLE
Update PyPI version badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="./docs/_static/timflow_logo.jpeg" width="300">
 
-![PyPI - Version](https://img.shields.io/pypi/v/timflow)
+[![PyPI - Version](https://img.shields.io/pypi/v/timflow)](https://pypi.org/project/timflow/)
 [![General](https://github.com/timflow-org/timflow/actions/workflows/ci-general.yml/badge.svg)](https://github.com/timflow-org/timflow/actions/workflows/ci-general.yml)
 [![Steady](https://github.com/timflow-org/timflow/actions/workflows/ci-steady.yml/badge.svg)](https://github.com/timflow-org/timflow/actions/workflows/ci-steady.yml)
 [![Transient](https://github.com/timflow-org/timflow/actions/workflows/ci-transient.yml/badge.svg)](https://github.com/timflow-org/timflow/actions/workflows/ci-transient.yml)


### PR DESCRIPTION
The pypi logo was not leading to Pypi. Added it to the [Python Hydrology list](https://github.com/raoulcollenteur/Python-Hydrology-Tools) that's how I found out :)
