### PR TITLE
Ensure `fitresult.covar` is not None before processing

### DIFF
--- a/timflow/transient/fit.py
+++ b/timflow/transient/fit.py
@@ -344,7 +344,7 @@ class Calibrate:
                 self.parameters.loc[name, "optimal"] = self.fitresult.params.valuesdict()[
                     name
                 ]
-            if hasattr(self.fitresult, "covar"):
+            if hasattr(self.fitresult, "covar") and self.fitresult.covar is not None:
                 self.parameters["std"] = np.sqrt(np.diag(self.fitresult.covar))
                 self.parameters["perc_std"] = (
                     100 * self.parameters["std"] / np.abs(self.parameters["optimal"])


### PR DESCRIPTION
I'm running into an issue where the `fitresult.covar` is None. 

```
Fit succeeded. Could not estimate error-bars.
[[Fit Statistics]]
    # fitting method   = leastsq
    # function evals   = 34
    # data points      = 300
    # variables        = 3
    chi-square         = 22518.4864
    reduced chi-square = 75.8198197
    Akaike info crit   = 1301.49282
    Bayesian info crit = 1312.60417
##  Warning: uncertainties could not be estimated:
    c_0_0:    at initial value
[[Variables]]
    kaq_0_1:  256.584548 (init = 100)
    c_0_0:    1000.00000 (init = 1000)
    Saq_0_1:  7.4078e-05 (init = 0.0001)
```