### PR TITLE
Add option to specify layer names to xsection plots

### DIFF
--- a/docs/steady/00userguide/howtos/howto_select_a_model.ipynb
+++ b/docs/steady/00userguide/howtos/howto_select_a_model.ipynb
@@ -134,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = ml.plots.xsection(params=True, labels=True, units={\"kaq\": \"m/d\", \"c\": \"d\"})\n",
+    "ax = ml.plots.xsection(params=True, labels=True, units={\"kaq\": \"m/d\"})\n",
     "ax.set_frame_on(False)"
    ]
   },

--- a/docs/transient/00userguide/howtos/howto_select_a_model.ipynb
+++ b/docs/transient/00userguide/howtos/howto_select_a_model.ipynb
@@ -45,7 +45,10 @@
     "    tmax=10,\n",
     ")\n",
     "\n",
-    "ax = ml.plots.xsection(params=True)\n",
+    "ax = ml.plots.xsection(\n",
+    "    params=True,\n",
+    "    units={\"kaq\": \"m/d\", \"c\": \"d\", \"Saq\": \"m$^{-1}$\", \"Sll\": \"m$^{-1}$\"},\n",
+    ")\n",
     "ax.set_frame_on(False)"
    ]
   },
@@ -77,7 +80,7 @@
     "    tmax=10,\n",
     ")\n",
     "\n",
-    "ax = ml2.plots.xsection(params=True)\n",
+    "ax = ml2.plots.xsection(params=True, units={\"kaq\": \"m/d\", \"Saq\": \"m$^{-1}$\"})\n",
     "ax.set_frame_on(False)"
    ]
   }

--- a/timflow/plots/plots.py
+++ b/timflow/plots/plots.py
@@ -81,14 +81,15 @@ class PlotBase:
     def xsection(
         self,
         xy: Optional[list[tuple[float]]] = None,
-        labels=True,
-        params=False,
-        names=False,
+        labels: bool = True,
+        params: bool = False,
+        names: bool = False,
         ax=None,
-        fmt=None,
-        units=None,
-        hstar=None,
-        boundaries=True,
+        fmt: str | None = None,
+        units: dict | None = None,
+        layer_names: tuple | dict = ("aquifer", "leaky layer"),
+        hstar: float | None = None,
+        boundaries: bool = True,
         horizontal_axis: Literal["x", "y", "s"] = "s",
         sep: Literal[", ", "\n"] = ", ",
         ha: str = "center",
@@ -119,6 +120,10 @@ class PlotBase:
         units : dict, optional
             dictionary with units keyed by timflow parameter names,
             e.g. {'kaq': 'm/d', 'c': 'd', 'Saq': 'm$^{-1}$', 'Sll': 'm$^{-1}$'}
+        layer_names : tuple or dict
+            names for aquifers and leaky layers, default is ('aquifer', 'leaky layer').
+            If a dict is provided, it maps layer type and number to a name,
+            e.g. {'aquifer 0': 'top aquifer', 'leaky layer 1': 'clay layer'}
         horizontal_axis : str
             's' for distance along cross-section on x-axis (default)
             'x' for using x-coordinates on x-axis
@@ -158,6 +163,7 @@ class PlotBase:
                 ax=ax,
                 fmt=fmt,
                 units=units,
+                layer_names=layer_names,
                 hstar=hstar,
                 boundaries=boundaries,
                 sep=sep,
@@ -176,7 +182,19 @@ class PlotBase:
 
         # Plot layers
         self._xection_plot_layers(
-            r0, r, labels, params, fmt, units, lli, aqi, ax, sep=sep, ha=ha, **kwargs
+            r0,
+            r,
+            labels,
+            params,
+            fmt,
+            units,
+            layer_names,
+            lli,
+            aqi,
+            ax,
+            sep=sep,
+            ha=ha,
+            **kwargs,
         )
 
         # Plot aquifer-aquifer boundaries
@@ -279,6 +297,7 @@ class PlotBase:
         ax,
         fmt,
         units=None,
+        layer_names=("aquifer", "leaky layer"),
         hstar=None,
         boundaries=True,
         sep: Literal[", ", "\n"] = ", ",
@@ -323,6 +342,7 @@ class PlotBase:
             x2=x2,
             fmt=fmt,
             units=units,
+            layer_names=layer_names,
             sep=sep,
             ha=ha,
         )
@@ -352,6 +372,7 @@ class PlotBase:
         x2,
         fmt,
         units,
+        layer_names,
         sep: Literal[", ", "\n"] = ", ",
         ha: str = "center",
     ):
@@ -374,11 +395,19 @@ class PlotBase:
         units : dict or None
             Dictionary of units keyed by timflow parameter names
             e.g. {'kaq': 'm/d', 'c': 'd', 'Saq': 'm$^{-1}$', 'Sll': 'm$^{-1}$'}.
+        layer_names : tuple or dict
+            names for aquifers and leaky layers, default is ('aquifer', 'leaky layer').
+            If a dict is provided, it maps layer type and number to a name,
+            e.g. {'aquifer 0': 'top aquifer', 'leaky layer 1': 'clay layer'
         sep : str, optional
             Separator between parameters, either ", " or "\n"
         ha : str, optional
             Horizontal alignment for parameter labels. Defaults to "center".
         """
+        if len(self._ml.aq.inhomdict) == 0:
+            raise ValueError(
+                "No inhomogeneities found in ModelXsection, nothing to plot."
+            )
         for inhom in self._ml.aq.inhomdict.values():
             inhom.plot(
                 ax=ax,
@@ -389,6 +418,7 @@ class PlotBase:
                 x2=x2,
                 fmt=fmt,
                 units=units,
+                layer_names=layer_names,
                 sep=sep,
                 ha=ha,
             )
@@ -458,6 +488,7 @@ class PlotBase:
         params,
         fmt,
         units,
+        layer_names,
         lli,
         aqi,
         ax,
@@ -479,6 +510,10 @@ class PlotBase:
             Whether to add parameter values
         fmt : str
             Format string for parameter values
+        layer_names : tuple or dict
+            names for aquifer and leaky layer, default is ('aquifer', 'leaky layer').
+            If a dict is provided, it maps layer type and number to a name,
+            e.g. {'aquifer 0': 'top aquifer', 'leaky layer 1': 'clay layer'}
         units : dict or None
             Dictionary of units keyed by timflow parameter names
             e.g. {'kaq': 'm/d', 'c': 'd', 'Saq': 'm$^{-1}$', 'Sll': 'm$^{-1}$'}
@@ -507,10 +542,17 @@ class PlotBase:
                     **kwargs,
                 )
                 if labels:
+                    if isinstance(layer_names, tuple):
+                        llname = f"{layer_names[1]} {lli}"
+                    elif isinstance(layer_names, dict):
+                        llname = f"leaky layer {lli}"
+                        llname = layer_names.get(llname, llname)
+                    else:
+                        llname = f"leaky layer {lli}"
                     ax.text(
                         r0 + 0.5 * r if not params else r0 + 0.25 * r,
                         np.mean(self._ml.aq.z[i : i + 2]),
-                        f"leaky layer {lli}",
+                        llname,
                         ha="center",
                         va="center",
                     )
@@ -524,10 +566,17 @@ class PlotBase:
             # Plot aquifers
             if self._ml.aq.ltype[i] == "a":
                 if labels:
+                    if isinstance(layer_names, tuple):
+                        aqname = f"{layer_names[0]} {aqi}"
+                    elif isinstance(layer_names, dict):
+                        aqname = f"aquifer {aqi}"
+                        aqname = layer_names.get(aqname, aqname)
+                    else:
+                        aqname = f"aquifer {aqi}"
                     ax.text(
                         r0 + 0.5 * r if not params else r0 + 0.25 * r,
                         np.mean(self._ml.aq.z[i : i + 2]),
-                        f"aquifer {aqi}",
+                        aqname,
                         ha="center",
                         va="center",
                         **kwargs,

--- a/timflow/steady/inhomogeneity1d.py
+++ b/timflow/steady/inhomogeneity1d.py
@@ -145,11 +145,12 @@ class Xsection(AquiferData):
     def plot(
         self,
         ax=None,
-        labels=False,
-        params=False,
-        names=False,
-        fmt=None,
-        units: dict = None,
+        labels: bool = False,
+        params: bool = False,
+        names: bool = False,
+        fmt: str | None = None,
+        units: dict | None = None,
+        layer_names: tuple | dict = ("aquifer", "leaky layer"),
         ha: str = "center",
         **kwargs,
     ):
@@ -171,6 +172,10 @@ class Xsection(AquiferData):
             Dictionary with units for parameters, only used if params is True.
             Use timflow parameter names as keys e.g.
             {"kaq": "m/d", "c": "d"}.
+        layer_names : tuple or dict, optional
+            names for aquifers and leaky layers, default is ('aquifer', 'leaky layer').
+            If a dict is provided, it maps layer type and number to a name,
+            e.g. {'aquifer 0': 'top aquifer', 'leaky layer 1': 'clay layer'
         ha : str, optional
             Horizontal alignment for parameter labels. Defaults to "center".
         """
@@ -238,10 +243,17 @@ class Xsection(AquiferData):
                     color=[0.8, 0.8, 0.8],
                 )
                 if labels:
+                    if isinstance(layer_names, tuple):
+                        llname = f"{layer_names[1]} {lli}"
+                    elif isinstance(layer_names, dict):
+                        llname = f"leaky layer {lli}"
+                        llname = layer_names.get(llname, llname)
+                    else:
+                        llname = f"leaky layer {lli}"
                     ax.text(
                         r0 + 0.5 * r if not params else r0 + 0.25 * r,
                         np.mean(self.z[i : i + 2]),
-                        f"leaky layer {lli}",
+                        llname,
                         ha="center",
                         va="center",
                     )
@@ -258,10 +270,17 @@ class Xsection(AquiferData):
                     lli += 1
 
             if labels and self.ltype[i] == "a":
+                if isinstance(layer_names, tuple):
+                    aqname = f"{layer_names[0]} {aqi}"
+                elif isinstance(layer_names, dict):
+                    aqname = f"aquifer {aqi}"
+                    aqname = layer_names.get(aqname, aqname)
+                else:
+                    aqname = f"aquifer {aqi}"
                 ax.text(
                     r0 + 0.5 * r if not params else r0 + 0.25 * r,
                     np.mean(self.z[i : i + 2]),
-                    f"aquifer {aqi}",
+                    aqname,
                     ha="center",
                     va="center",
                 )

--- a/timflow/transient/inhom1d.py
+++ b/timflow/transient/inhom1d.py
@@ -209,12 +209,13 @@ class Xsection(AquiferData):
     def plot(
         self,
         ax=None,
-        labels=False,
-        params=False,
-        names=False,
-        fmt=None,
+        labels: bool = False,
+        params: bool = False,
+        names: bool = False,
+        fmt: str | None = None,
         sep: Literal[", ", "\n"] = ", ",
         units: dict = None,
+        layer_names: tuple | dict = ("aquifer", "leaky layer"),
         ha: str = "center",
         **kwargs,
     ):
@@ -238,6 +239,12 @@ class Xsection(AquiferData):
             Dictionary with units for parameters, only used if params is True.
             Use timflow parameter names as keys e.g.
             {"kaq": "m/d", "c": "d", "Saq": "m$^{-1}$", "Sll": "m$^{-1}$"}.
+        layer_names : tuple or dict, optional
+            names for aquifers and leaky layers, default is ('aquifer', 'leaky layer').
+            If a dict is provided, it maps layer type and number to a name,
+            e.g. {'aquifer 0': 'top aquifer', 'leaky layer 1': 'clay layer'}
+        sep : str, optional
+            Separator between parameters, either ", " or "\n"
         ha : str, optional
             Horizontal alignment for parameter labels. Defaults to "center".
 
@@ -311,10 +318,17 @@ class Xsection(AquiferData):
                     color=[0.8, 0.8, 0.8],
                 )
                 if labels:
+                    if isinstance(layer_names, tuple):
+                        llname = f"{layer_names[1]} {lli}"
+                    elif isinstance(layer_names, dict):
+                        llname = f"leaky layer {lli}"
+                        llname = layer_names.get(llname, llname)
+                    else:
+                        llname = f"leaky layer {lli}"
                     ax.text(
                         r0 + 0.5 * r if not params else r0 + 0.25 * r,
                         np.mean(self.z[i : i + 2]),
-                        f"leaky layer {lli}",
+                        llname,
                         ha="center",
                         va="center",
                     )
@@ -338,10 +352,17 @@ class Xsection(AquiferData):
                     lli += 1
 
             if labels and self.ltype[i] == "a":
+                if isinstance(layer_names, tuple):
+                    aqname = f"{layer_names[0]} {aqi}"
+                elif isinstance(layer_names, dict):
+                    aqname = f"aquifer {aqi}"
+                    aqname = layer_names.get(aqname, aqname)
+                else:
+                    aqname = f"aquifer {aqi}"
                 ax.text(
                     r0 + 0.5 * r if not params else r0 + 0.25 * r,
                     np.mean(self.z[i : i + 2]),
-                    f"aquifer {aqi}",
+                    aqname,
                     ha="center",
                     va="center",
                 )


### PR DESCRIPTION
I thought the steady Model class was still broken (plotting cross sections), so while debugging I decided to implement custom layer naming. Turned out my browser was just loading a cached version of the old docs, so it wasn't broken after all. But now we have custom layer naming. 

- default is ("aquifer", "leaky layer")
- specify tuple with alternative names OR specify dict with mapping of specific layers to custom names
- fix units in select model notebooks
- type hints in xsection plot methods to help users input correct stuff

