### PR TITLE
Using cmap instead of color when plotting contours causes error

### DIFF
--- a/timflow/plots/plots.py
+++ b/timflow/plots/plots.py
@@ -838,7 +838,10 @@ class PlotBase:
         cslist = []
         cshandlelist = []
         for i in range(len(layers)):
-            _colors = c if per_level_colors else c[i]
+            if color is None and cmap is not None:
+                _colors = None
+            else:
+                _colors = c if per_level_colors else c[i]
             iarr = arr[i] if arr.ndim == 3 else arr
             cs = ax.contour(x, y, iarr, levels, colors=_colors, cmap=cmap, **kwargs)
             cslist.append(cs)


### PR DESCRIPTION
File affected: timflow/plots/plots.py

If passing `color=None` with a valid cmap when plotting contours an index error is raised on:

Line 841: `_colors = c if per_level_colors else c[i]`

I suggest an if statement to check whether color is None and cmap is not None, if that is the case then _colors is assigned None so that cmap is used. Otherwise, continue as previously.