### PR TITLE
Top boundary reference and method

### DIFF
--- a/timflow/steady/aquifer.py
+++ b/timflow/steady/aquifer.py
@@ -89,6 +89,8 @@ class AquiferData:
         else:
             self.nporll = self.npor[self.ltype == "l"]
         self.model3d = model3d
+        # set reference to top boundary for background aquifers and inhoms
+        self.topbc = None  # top boundary condition element, if any
 
     def initialize(self):
         self.elementlist = []  # Elementlist of aquifer

--- a/timflow/steady/aquifer_parameters.py
+++ b/timflow/steady/aquifer_parameters.py
@@ -20,7 +20,7 @@ def param_maq(kaq, z, c, npor, top):
     npor : float or array of floats
         Porosity of the aquifer(s).
     top : string
-        'conf' for confined aquifer on top, 'leak' for leaky layer on top.
+        'conf' for confined aquifer on top, 'semi' for semi-confined aquifer on top.
 
     Returns
     -------

--- a/timflow/steady/constant.py
+++ b/timflow/steady/constant.py
@@ -176,8 +176,6 @@ class ConstantInside(Element):
         self.parameters[:, 0] = sol
 
 
-# class ConstantStar(Element, PotentialEquation):
-# I don't think we need the equation
 class ConstantStar(Element):
     """Constant representing the particular solution inside a semi-confined aquifer.
 

--- a/timflow/steady/inhomogeneity.py
+++ b/timflow/steady/inhomogeneity.py
@@ -139,10 +139,12 @@ class PolygonInhom(AquiferData):
             if self.N is not None:
                 a = AreaSinkInhom(self.model, self.N, self.xcenter, aq=aqin)
                 a.inhomelement = True
+                self.topbc = a
         if aqin.ltype[0] == "l":
             assert self.hstar is not None, "Error: hstar needs to be set"
             c = ConstantStar(self.model, self.hstar, aq=aqin)
             c.inhomelement = True
+            self.topbc = c
 
 
 class PolygonInhomMaq(PolygonInhom):
@@ -543,6 +545,7 @@ class BuildingPit(AquiferData):
             assert self.hstar is not None, "Error: hstar needs to be set"
             c = ConstantStar(self.model, self.hstar, aq=aqin)
             c.inhomelement = True
+            self.topbc = c
 
 
 class BuildingPitMaq(BuildingPit):
@@ -915,6 +918,7 @@ class LeakyBuildingPit(BuildingPit):
             assert self.hstar is not None, "Error: hstar needs to be set"
             c = ConstantStar(self.model, self.hstar, aq=aqin)
             c.inhomelement = True
+            self.topbc = c
 
 
 class LeakyBuildingPitMaq(LeakyBuildingPit):

--- a/timflow/steady/inhomogeneity1d.py
+++ b/timflow/steady/inhomogeneity1d.py
@@ -135,12 +135,15 @@ class Xsection(AquiferData):
                 assert aqin.ilap, (
                     "Error: infiltration can only be added if topboundary='conf'"
                 )
-                XsectionAreaSinkInhom(self.model, self.x1, self.x2, self.N, layer=0)
+                self.topbc = XsectionAreaSinkInhom(
+                    self.model, self.x1, self.x2, self.N, layer=0
+                )
 
         if aqin.ltype[0] == "l":
             assert self.hstar is not None, "Error: hstar needs to be set"
             c = ConstantStar(self.model, self.hstar, aq=aqin)
             c.inhomelement = True
+            self.topbc = c
 
     def plot(
         self,

--- a/timflow/steady/model.py
+++ b/timflow/steady/model.py
@@ -80,9 +80,11 @@ class Model:
         array indicating for each layer whether it is
         'a' aquifer layer
         'l' leaky layer
+    hstar : float, optional
+        head above the top leaky layer, only used if top is semi-confined.
     """
 
-    def __init__(self, kaq, z, c, npor, ltype, model3d=False):
+    def __init__(self, kaq, z, c, npor, ltype, model3d=False, hstar=None):
         # All input variables are numpy arrays
         # That should be checked outside this function
         self.elementlist = []
@@ -91,8 +93,10 @@ class Model:
         self.name = "Model"
         self.model_type = "steady"  # Model type for plotting and other purposes
 
-        self.plots = PlotSteady(self)
+        if self.aq.ltype[0] == "l":
+            self.aq.topbc = ConstantStar(self, hstar, aq=self.aq)
 
+        self.plots = PlotSteady(self)
         self.initialized = False
 
     def initialize(self):
@@ -1036,10 +1040,8 @@ class ModelMaq(Model):
         if z is None:
             z = [1, 0]
         kaq, c, npor, ltype = param_maq(kaq, z, c, npor, topboundary)
-        super().__init__(kaq=kaq, z=z, c=c, npor=npor, ltype=ltype)
+        super().__init__(kaq=kaq, z=z, c=c, npor=npor, ltype=ltype, hstar=hstar)
         self.name = "ModelMaq"
-        if self.aq.ltype[0] == "l":
-            ConstantStar(self, hstar, aq=self.aq)
 
 
 class Model3D(Model):
@@ -1119,11 +1121,11 @@ class Model3D(Model):
         if topboundary == "semi":
             z = np.hstack((z[0] + topthick, z))
         model3d = True
-        super().__init__(kaq=kaq, z=z, c=c, npor=npor, ltype=ltype, model3d=model3d)
+        super().__init__(
+            kaq=kaq, z=z, c=c, npor=npor, ltype=ltype, model3d=model3d, hstar=hstar
+        )
         self.aq.kzoverkh = kzoverkh  # add kzoverkh to aquifer object
         self.name = "Model3D"
-        if self.aq.ltype[0] == "l":
-            ConstantStar(self, hstar, aq=self.aq)
 
 
 class ModelXsection(Model):

--- a/timflow/transient/aquifer.py
+++ b/timflow/transient/aquifer.py
@@ -87,6 +87,8 @@ class AquiferData:
         # self.D = self.T / self.Saq
         self.area = 1e200  # Smaller than default of ml.aq so that inhom is found
         self.name = name
+        # set reference to top boundary element for background aquifers and inhoms
+        self.topbc = None  # top boundary condition element, if any
 
     def __repr__(self):
         if self.topboundary.startswith("con"):

--- a/timflow/transient/element.py
+++ b/timflow/transient/element.py
@@ -333,3 +333,31 @@ class Element(ABC):
     @abstractmethod
     def plot(self, ax=None):
         """Plot the element."""
+
+    def get_bc(self, t):
+        """Get the boundary condition at time(s) t.
+
+        Parameters
+        ----------
+        t : scalar or array
+            Time(s) at which to get the boundary condition.
+
+        Returns
+        -------
+        bc : scalar or array
+            Boundary condition(s) at time t.
+        """
+        t = np.atleast_1d(t)
+        bc = np.zeros_like(t, dtype=float)
+
+        if self.ntstart == 1:
+            bc[t >= self.tstart[0]] = self.bcin[0]
+        else:
+            for itime in range(self.ntstart):
+                if itime == self.ntstart - 1:
+                    mask = t >= self.tstart[itime]
+                else:
+                    mask = (t >= self.tstart[itime]) & (t < self.tstart[itime + 1])
+                bc[mask] = self.bcin[itime]
+
+        return bc if len(bc) > 1 else bc[0]

--- a/timflow/transient/inhom1d.py
+++ b/timflow/transient/inhom1d.py
@@ -205,12 +205,14 @@ class Xsection(AquiferData):
             assert self.topboundary == "con" or self.topboundary == "phr", Exception(
                 "Infiltration can only be applied to a confined aquifer."
             )
-            AreaSinkXsection(self.model, self.x1, self.x2, tsandN=self.tsandN)
+            self.topbc = AreaSinkXsection(self.model, self.x1, self.x2, tsandN=self.tsandN)
         if self.tsandhstar is not None:
             assert self.topboundary == "sem", Exception(
                 "hstar can only be implemented on top of a semi-confined aquifer."
             )
-            HstarXsection(self.model, self.x1, self.x2, tsandhstar=self.tsandhstar)
+            self.topbc = HstarXsection(
+                self.model, self.x1, self.x2, tsandhstar=self.tsandhstar
+            )
 
     def plot(
         self,

--- a/timflow/transient/inhom1d.py
+++ b/timflow/transient/inhom1d.py
@@ -205,7 +205,9 @@ class Xsection(AquiferData):
             assert self.topboundary == "con" or self.topboundary == "phr", Exception(
                 "Infiltration can only be applied to a confined aquifer."
             )
-            self.topbc = AreaSinkXsection(self.model, self.x1, self.x2, tsandN=self.tsandN)
+            self.topbc = AreaSinkXsection(
+                self.model, self.x1, self.x2, tsandN=self.tsandN
+            )
         if self.tsandhstar is not None:
             assert self.topboundary == "sem", Exception(
                 "hstar can only be implemented on top of a semi-confined aquifer."


### PR DESCRIPTION
Adds a reference to the top boundary element. Mostly useful for transient models to get access to top boundary element and inspect the top boundary condition. Also added to steady model to be consistent.

In steady, `ml.aq.topbc` or `inhom.topbc` holds reference to `ConstantStar`, `AreaSinkInhom` or `XsectionAreaSinkInhom` depending on the type of model/inhom. 

In transient `xsection.topbc` holds reference to `HstarXsection` or `AreaSinkXsection`. 

Adds method `.get_bc()` to transient element class to obtain time series of any `.tsandbc` which could be useful for plotting or comparison to other time series etc. 

```python
riv = tft.XsectionMaq(..., tsandhstar=[(0, 1), (1, 2), (2, 0)])
riv.topbc  # --> HstarXsection element

t = np.arange(0, 2, 0.1)
riv.topbc.get_bc(t)  # --> returns array of hstar values
```